### PR TITLE
Keep the initial values consistent to avoid assertion errors

### DIFF
--- a/src/trace_session.c
+++ b/src/trace_session.c
@@ -36,7 +36,7 @@ static ExecutorRun_hook_type prev_ExecutorRun_hook = NULL; // hook to log plan b
 bool isExecuteTime = false;
 
 //GUC parametrs
-int writeMode = TEXT_WRITE_MODE;
+int writeMode = JSON_WRITE_MODE;
 bool traceLWLocksForEachNode;
 bool writeOnlySleepLWLocksStat;
 


### PR DESCRIPTION
#1 